### PR TITLE
Convert V13 HTML to jQuery

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,14 +2,16 @@
   "id": "token-stack-selector",
   "title": "Token Stack Selector",
   "description": "Interface moderna para seleção de tokens empilhados no Foundry VTT. Permite escolher facilmente entre tokens sobrepostos com um painel elegante similar ao sistema de condições.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "authors": [
     {
       "name": "Sub-Dev",
       "discord": "sub-dev"
     }
   ],
-  "esmodules": ["main.js"],
+  "esmodules": [
+    "main.js"
+  ],
   "compatibility": {
     "minimum": "11",
     "verified": "12",

--- a/src/token-stack-selector.js
+++ b/src/token-stack-selector.js
@@ -79,9 +79,9 @@ export class TokenStackSelector {
 
       // Adiciona botão ao HUD
       const button = TokenStackButton.addToHUD(
-        html,
+        $(html),
         visibleTokens.length,
-        () => this.handleButtonClick(visibleTokens, html, button)
+        () => this.handleButtonClick(visibleTokens, $(html), button)
       );
 
     } catch (error) {


### PR DESCRIPTION
V13 no longer pass jQuery object but the lib is still available. We just upgrade the html variable before passing to TokenStackSelector.